### PR TITLE
SAKORA-8 infinite loop processing academic sessions

### DIFF
--- a/sakora-csv-impl/impl/pom.xml
+++ b/sakora-csv-impl/impl/pom.xml
@@ -55,9 +55,8 @@
             <artifactId>coursemanagement-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.sakaiproject</groupId>
+            <groupId>org.sakaiproject.genericdao</groupId>
             <artifactId>generic-dao</artifactId>
-            <version>0.9.18</version>
         </dependency>
 
         <!-- Spring and Hibernate Dependencies -->

--- a/sakora-csv-impl/impl/src/java/net/unicon/sakora/impl/csv/CsvAcademicSessionHandler.java
+++ b/sakora-csv-impl/impl/src/java/net/unicon/sakora/impl/csv/CsvAcademicSessionHandler.java
@@ -107,20 +107,11 @@ public class CsvAcademicSessionHandler extends CsvHandlerBase {
 
 		Search search = new Search();
 		search.addRestriction(new Restriction("inputTime", time, Restriction.EQUALS));
-
-		boolean done = false;
-
-		while (!done) {
-			List<Session> sessions = dao.findBySearch(Session.class, search);
-			for (Session session : sessions) {
-				currentSessions.add(session.getEid());
-			}
-			if (sessions == null || sessions.size() == 0) {
-				done = true;
-			} else {
-				search.setStart(search.getStart() + searchPageSize);
-			}
+		List<Session> sessions = dao.findBySearch(Session.class, search);
+		for (Session session : sessions) {
+			currentSessions.add(session.getEid());
 		}
+
         if (currentSessions.isEmpty() && !commonHandlerService.ignoreMissingSessions()) {
             // TODO should we die here? -AZ
             /* 


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAKORA-8

Since the move to GitHub, changes to generic-dao seem to have caused an infinite loop processing academic sessions. From CsvAcademicSessionHandler.java:

```
ArrayList<String> currentSessions = new ArrayList<String>();
Search search = new Search();
search.addRestriction(new Restriction("inputTime", time, Restriction.EQUALS));

boolean done = false;
while (!done) {
        List<Session> sessions = dao.findBySearch(Session.class, search);
        for (Session session : sessions) {
            currentSessions.add(session.getEid());
        }
        if (sessions == null || sessions.size() == 0) {
            done = true;
        } else {
            search.setStart(search.getStart() + searchPageSize);
        }
    }
```

`dao.findBySearch()` returns the same result set on each iteration. Thus, done is never set to true and the loop runs indefinately.

The actual cause of this is that the following piece of code was not present:

`search.setLimit(searchPageSize);`

Adding the above snippet solves the issue, and the dao returns the proper results in each iteration. However, I chose to eliminate pagination of this query for the following reasons:
1. In this situation, the pagination only saves a very small amount of RAM. The only savings is the RAM required to store a java.util.Date object inside the Session objects, and only if there are more than 1000 academic sessions in the system. This is highly unlikely
2. Readability and understanding the code is greatly simplified by omitting the pagination for this particular query
