### PR TITLE
SAKORA-16: avoid sakora failing on null enrollment set

### DIFF
--- a/sakora-csv-impl/impl/src/java/net/unicon/sakora/impl/csv/CsvMembershipHandler.java
+++ b/sakora-csv-impl/impl/src/java/net/unicon/sakora/impl/csv/CsvMembershipHandler.java
@@ -242,9 +242,13 @@ public class CsvMembershipHandler extends CsvHandlerBase {
                                     Section section = cmService.getSection(membership.getContainerEid());
                                     if (section != null) {
                                         EnrollmentSet enrolled = section.getEnrollmentSet();
-                                        cmAdmin.removeEnrollment(membership.getUserEid(), enrolled.getEid());
-                                        if (LOG.isDebugEnabled()) LOG.debug("SakoraCSV removed "+mode+" membership for "+membership.getUserEid()+": "+enrolled.getEid());
-                                        deletes++;
+                                        if (enrolled != null) {
+                                            cmAdmin.removeEnrollment(membership.getUserEid(), enrolled.getEid());
+                                            if (LOG.isDebugEnabled()) LOG.debug("SakoraCSV removed "+mode+" membership for "+membership.getUserEid()+": "+enrolled.getEid());
+                                            deletes++;
+                                        } else {
+                                            LOG.info("Null EnrollmentSet found for section EID " + section.getEid() + ", enrollments for this set can't be removed...");
+                                        }
                                     }
                                 } else {
                                     cmAdmin.removeCourseOfferingMembership(membership.getUserEid(), membership.getContainerEid());


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAKORA-16

In September 2018, we experienced Sakora failing to finish for three weeks because an NPE caused it to fail while it was processing a batch of drops. The issue was caused by a null enrollment set in the CM_MEMBER_CONTAINER_T table. Resulting log statement:

> 19-Sep-2018 13:17:38.723 INFO [QuartzScheduler_Worker-3] net.unicon.sakora.impl.csv.CsvCommonHandlerService.setCurrentHandlerState SakoraCSV: Sync (1:1537364508): SectionMembership state is: fail
> 19-Sep-2018 13:17:38.723 ERROR [QuartzScheduler_Worker-3] net.unicon.sakora.impl.csv.CsvSyncServiceImpl.handleAction Failed to process batch at [/tomcat/sakai/sakora-csv/sakora-csv-batch-1537364508273] during action [Section Membership]. Skipping remainder of batch.
> java.lang.NullPointerException
> 	at net.unicon.sakora.impl.csv.CsvMembershipHandler.processInternal(CsvMembershipHandler.java:245)
> 	at net.unicon.sakora.impl.csv.CsvHandlerBase.process(CsvHandlerBase.java:297)
> 	at net.unicon.sakora.impl.csv.CsvSyncServiceImpl.handleAction(CsvSyncServiceImpl.java:172)
> 	at net.unicon.sakora.impl.csv.CsvSyncServiceImpl.sync(CsvSyncServiceImpl.java:238)
> 	at net.unicon.sakora.impl.jobs.CsvLoaderJobBean.execute(CsvLoaderJobBean.java:45)
> 	at org.sakaiproject.component.app.scheduler.jobs.SpringStatefulJobBeanWrapper.execute(SpringStatefulJobBeanWrapper.java:24)
> 	at org.quartz.core.JobRunShell.run(JobRunShell.java:202)
> 	at org.quartz.simpl.SimpleThreadPool$WorkerThread.run(SimpleThreadPool.java:573)
> 19-Sep-2018 13:17:38.735 INFO [QuartzScheduler_Worker-3] net.unicon.sakora.impl.csv.CsvMembershipHandler.after SakoraCSV handler Membership completed processing 713960 lines with 0 errors: adds=0, updates=710095, deletes=93305
> 19-Sep-2018 13:17:38.735 INFO [QuartzScheduler_Worker-3] net.unicon.sakora.impl.csv.CsvCommonHandlerService.setCurrentHandlerState SakoraCSV: Sync (1:1537364508): SectionMembership state is: done

It is legitimate to have a null enrollment set, so to avoid bombing out in this scenario the code just needs a simple null check and a logger statement indicating what happened.