### PR TITLE
SAKORA-18: catch CsvValidationException in CsvHandlerBase

### DIFF
--- a/sakora-csv-impl/impl/src/java/net/unicon/sakora/impl/csv/CsvHandlerBase.java
+++ b/sakora-csv-impl/impl/src/java/net/unicon/sakora/impl/csv/CsvHandlerBase.java
@@ -57,6 +57,7 @@ import org.sakaiproject.tool.api.SessionManager;
 import org.sakaiproject.user.api.UserDirectoryService;
 
 import com.opencsv.CSVReader;
+import com.opencsv.exceptions.CsvValidationException;
 
 /**
  * Base class which is extended by all CSV processors
@@ -215,6 +216,9 @@ public abstract class CsvHandlerBase implements CsvHandler {
 		} catch (IOException ioe) {
 			dao.create(new SakoraLog(this.getClass().toString(), ioe.getLocalizedMessage()));
 			log.warn("SakoraCSV reader failed to read from file [" + csvPath + "]: "+ioe, ioe);
+		} catch (CsvValidationException cve) {
+			dao.create(new SakoraLog(this.getClass().toString(), cve.getLocalizedMessage()));
+			log.warn("SakoraCSV reader failed validation of file [" + csvPath + "]: "+cve, cve);
 		}
 		return fileWasRead;
 	}
@@ -273,6 +277,9 @@ public abstract class CsvHandlerBase implements CsvHandler {
 		        // can be thrown by methods in readInputLine but generally this is unlikely to happen because most (or all) handlers catch this exception themselves
 		        dao.create(new SakoraLog(this.getClass().toString(), getClass().getSimpleName() + ":: " + ine.getLocalizedMessage()));
 		        log.error(getClass().getSimpleName() + ":: " + ine.getLocalizedMessage(), ine);
+		    } catch (CsvValidationException cve) {
+		        dao.create(new SakoraLog(this.getClass().toString(), cve.getLocalizedMessage()));
+		        log.warn("SakoraCSV reader failed validation of file [" + context.getProperties().get(BATCH_FILE_PATH) + "]: "+cve, cve);
 		    }
 		    finally {
 		        logoutFromSakai();


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/SAKORA-18

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile (default-compile) on project sakai-sakora-csv-impl: Compilation failure: Compilation failure:
[ERROR] /sakora-csv/sakora-csv-impl/impl/src/java/net/unicon/sakora/impl/csv/CsvHandlerBase.java:[209,46] unreported exception com.opencsv.exceptions.CsvValidationException; must be caught or declared to be thrown
[ERROR] /sakora-csv/sakora-csv-impl/impl/src/java/net/unicon/sakora/impl/csv/CsvHandlerBase.java:[256,69] unreported exception com.opencsv.exceptions.CsvValidationException; must be caught or declared to be thrown
```

OpenCSV must have been upgraded in master, as this exception was not thrown before. 